### PR TITLE
add instructions for fixing sdkmanager error

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,9 @@
 
       If you are installing the tools for the very first time, you may need to
       accept the SDK license agreements. Run: ```sdkmanager --licenses```
-      to do so.
+      to do so. If you get errors running sdkmanager, install Google Play Licensing Library
+      in Android Studio -> Preferences -> Appearance & Behavior -> System Settings -> Android SDK
+      -> SDK Tools.
 
 5. Start the React Native Metro Bundler and leave it running.
    ```


### PR DESCRIPTION
When trying to follow these instructions to get started with application development, I was stuck with the following error when attempting to run `sdkmanager --licenses`:

> $ sdkmanager --licenses
> Exception in thread "main" java.lang.NoClassDefFoundError: javax/xml/bind/annotation/XmlSchema
> 	at com.android.repository.api.SchemaModule$SchemaModuleVersion.<init>(SchemaModule.java:156)
> 	at com.android.repository.api.SchemaModule.<init>(SchemaModule.java:75)
> 	at com.android.sdklib.repository.AndroidSdkHandler.<clinit>(AndroidSdkHandler.java:81)
> 	at com.android.sdklib.tool.sdkmanager.SdkManagerCli.main(SdkManagerCli.java:73)
> 	at com.android.sdklib.tool.sdkmanager.SdkManagerCli.main(SdkManagerCli.java:48)
> Caused by: java.lang.ClassNotFoundException: javax.xml.bind.annotation.XmlSchema
> 	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:581)
> 	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178)
> 	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522)
> 	... 5 more

I used the method described in the README.md to fix the issue. 