### PR TITLE
adds load screen and fixes sign out bug

### DIFF
--- a/components/hamburgerMenu.js
+++ b/components/hamburgerMenu.js
@@ -61,7 +61,7 @@ export default function HamburgerMenu(props) {
     }
 
     getInitialData();
-  });
+  }, []);
 
   const onPress = route => {
     if (!isActiveRoute(route)) {

--- a/routes/mainStack.js
+++ b/routes/mainStack.js
@@ -33,14 +33,13 @@ export default function MainStack() {
   const [showPopupLogout, setShowPopupLogout] = useState(false);
   const [showPopupDelete, setShowPopupDelete] = useState(false);
 
-  const logout = () => {
-    Realm.destroyUser().then(() => {
-      if (!isActiveRoute('Home')) {
-        navigationRef.current?.navigate('Home');
-      }
-      setIsMenuOpen(false);
-      navigationRef.current?.navigate('OnboardingStack');
-    });
+  const logout = async () => {
+    if (!isActiveRoute('Home')) {
+      navigationRef.current?.navigate('Home');
+    }
+    setIsMenuOpen(false);
+    await Realm.destroyUser();
+    navigationRef.current?.navigate('OnboardingStack');
   };
 
   async function deleteUser() {

--- a/screens/main/home.js
+++ b/screens/main/home.js
@@ -182,6 +182,11 @@ export default function HomeScreen({navigation, route}) {
     getRecordedWalks(newDate);
   }
 
+  async function getWeeklyGoals() {
+    const weeklyGoals = await Realm.getWeeklyGoals();
+    setHasGoals(weeklyGoals.length > 0);
+  }
+
   const refresh = useCallback(
     function () {
       const today = moment().startOf('day');
@@ -194,6 +199,7 @@ export default function HomeScreen({navigation, route}) {
       getTotalSteps();
       getRecordedWalks(dateRef.current);
       saveStepsAndDistances();
+      getWeeklyGoals();
     },
     [getStepsAndDistances],
   );
@@ -284,15 +290,6 @@ export default function HomeScreen({navigation, route}) {
       AppState.removeEventListener('change', onAppStateChange);
     };
   }, [onAppStateChange]);
-
-  useEffect(() => {
-    async function getWeeklyGoals() {
-      const weeklyGoals = await Realm.getWeeklyGoals();
-      setHasGoals(weeklyGoals.length > 0);
-    }
-
-    getWeeklyGoals();
-  }, []);
 
   const today = moment().startOf('day');
   const isToday = date.isSame(today);

--- a/screens/onboarding/setYourStepGoal.js
+++ b/screens/onboarding/setYourStepGoal.js
@@ -1,5 +1,6 @@
 import React, {useEffect, useRef, useState} from 'react';
 import {
+  ActivityIndicator,
   SafeAreaView,
   ScrollView,
   StyleSheet,
@@ -21,7 +22,7 @@ export default function SetYourStepTarget({navigation, route}) {
   const DEFAULT_DAYS_GOAL = 4;
   const stepInputRef = useRef(null);
   const daysInputRef = useRef(null);
-  const [isLoading, setLoading] = useState(false);
+  const [loading, setLoading] = useState(false);
   const [stepGoal, setStepGoal] = useState(null);
   const [daysGoal, setDaysGoal] = useState(null);
   const [isStepLowerLimit, setStepLowerLimit] = useState(false);
@@ -37,7 +38,7 @@ export default function SetYourStepTarget({navigation, route}) {
   const daysGoalAndChangeEqual = daysGoal === DAYS_CHANGE;
 
   function onDecreaseSteps() {
-    if (isLoading || stepGoalAndChangeEqual) {
+    if (loading || stepGoalAndChangeEqual) {
       return;
     }
 
@@ -46,7 +47,7 @@ export default function SetYourStepTarget({navigation, route}) {
   }
 
   function onIncreaseSteps() {
-    if (isLoading || stepGoal >= 99500) {
+    if (loading || stepGoal >= 99500) {
       return;
     }
     setStepGoal(stepGoal + STEP_CHANGE);
@@ -54,7 +55,7 @@ export default function SetYourStepTarget({navigation, route}) {
   }
 
   function onDecreaseDays() {
-    if (isLoading || daysGoalAndChangeEqual) {
+    if (loading || daysGoalAndChangeEqual) {
       return;
     }
 
@@ -63,7 +64,7 @@ export default function SetYourStepTarget({navigation, route}) {
   }
 
   function onIncreaseDays() {
-    if (isLoading || daysGoal >= 7) {
+    if (loading || daysGoal >= 7) {
       return;
     }
 
@@ -98,6 +99,7 @@ export default function SetYourStepTarget({navigation, route}) {
   }
 
   useEffect(() => {
+    setLoading(true);
     // get current goal
     async function getWeeklyGoals() {
       const weeklyGoals = await Realm.getWeeklyGoals();
@@ -109,6 +111,7 @@ export default function SetYourStepTarget({navigation, route}) {
         setStepGoal(DEFUALT_STEP_GOAL);
         setDaysGoal(DEFAULT_DAYS_GOAL);
       }
+      setLoading(false);
     }
 
     getWeeklyGoals();
@@ -265,6 +268,12 @@ export default function SetYourStepTarget({navigation, route}) {
               <PaginationDots currentPage={6} totalPages={8} />
             )}
           </View>
+          {loading && (
+            <View style={styles.loader}>
+              <ActivityIndicator size="small" color={Colors.primary.purple} />
+              <Text style={styles.loaderText}>{Strings.common.pleaseWait}</Text>
+            </View>
+          )}
         </View>
       </ScrollView>
       <Popup isVisible={showAlert} onClose={() => setShowAlert(false)}>
@@ -367,5 +376,24 @@ const styles = StyleSheet.create({
     flex: 0,
     flexDirection: 'row',
     marginBottom: 16,
+  },
+  loader: {
+    position: 'absolute',
+    flexDirection: 'row',
+    height: '100%',
+    width: '105%',
+    left: 16,
+    top: 0,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: Colors.primary.lightGray,
+    borderRadius: 5,
+    marginLeft: -10,
+  },
+  loaderText: {
+    color: Colors.primary.purple,
+    fontSize: 24,
+    fontWeight: '500',
+    marginLeft: 10,
   },
 });


### PR DESCRIPTION
This PR adds a load screen to the set your goal screen, ensures that the weekly goals are fetched again on the home screen and fixes an issue with signing out.

I'd still like to get in an update to use realm, so we're not fetching weekly goals from the database each time, so that'll be coming soon.